### PR TITLE
reminder email reports the actual # of hours until reminders start

### DIFF
--- a/check-approved-requests.py
+++ b/check-approved-requests.py
@@ -155,7 +155,7 @@ def build_request_details(request_list, template):
 
 def send_reminder(reminders, request_type, worksheet_key):
     """Send a reminder email about an application waiting for approval
-    for more than 24 hours
+    for more than a given # of hours (specified in config)
     """
     reminder_cfg = dict(config.items('email_defaults'))
     reminder_cfg.update(dict(config.items('reminder')))
@@ -260,7 +260,8 @@ def check_requests(request_type, auth_file, worksheet_key):
             if args.log:
                 log_request(args.log, timestamp, request_info['user_email'])
         
-        # if request is not approved and is >24 hours old, send a reminder
+        # if request is not approved and is more than `reminder_start`
+        # hours old, send a reminder
         elif row[0] == '' and (now >= dateparser.parse(row[3]) +
                                reminder_start):
             # but only send if this is the first one, or if enough time

--- a/templates/reminder.txt
+++ b/templates/reminder.txt
@@ -1,6 +1,6 @@
 <html>
 <body>
-<p>This is an automated reminder that there are <REQUEST_COUNT> <REQUEST_TYPE> requests that have waited over 24 hours for approval.</p>
+<p>This is an automated reminder that there are <REQUEST_COUNT> <REQUEST_TYPE> requests that have waited over <START> hours for approval.</p>
 
 <p>Click this link to view the request spreadsheet:<br><a href="<REQUEST_SPREADSHEET>"><REQUEST_TYPE> Request Spreadsheet</a></p>
 


### PR DESCRIPTION
Report the actual number of hours when reminders start, which is set in config, instead of always 24 hours. 