### PR TITLE
switch mailing list from majordomo to mailman

### DIFF
--- a/example_settings.ini
+++ b/example_settings.ini
@@ -27,6 +27,12 @@ setpass_url =
 email =
 template =
 
+[mailman]
+mailman_server = 
+mailman_user = 
+subscribe_command = /usr/lib/mailman/bin/add_members --regular-members-file=- %(list_name)s
+list_name = 
+
 [reminder]
 # email address & template for sending a reminder for 
 # requests waiting for approval for more than 24 hours  


### PR DESCRIPTION
This is not very pretty but it works.  

If we ever upgrade to Mailman 3 there will be a nicer way to do it using the REST API but this seems to be the only option with Mailman 2.