### PR TITLE
Update reset-password.py to reference the correct config in settings.ini

### DIFF
--- a/reset-password.py
+++ b/reset-password.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
     url = setpass.get_url(token)
 
     email_config = dict(config.items('email_defaults'))
-    email_config.update(dict(config.items('reset_password_email')))
+    email_config.update(dict(config.items('password_reset_email')))
     
     email = TemplateMessage(email=args.username, fullname=args.username,
                             setpass_token_url=url, **email_config)


### PR DESCRIPTION
This is a bug fix in the password reset functionality. Currently, reset-password.py refers to a config called "reset_password_email," which no longer exists in settings.ini. This config is now called "password_reset_email." This patch changes reset-password.py to refer to the existing config name. The traceback from running reset-password.py is below, for reference.

```
Traceback (most recent call last):
  File "reset-password.py", line 108, in <module>
    email_config.update(dict(config.items('reset_password_email')))
  File "/usr/lib64/python2.7/ConfigParser.py", line 642, in items
    raise NoSectionError(section)
ConfigParser.NoSectionError: No section: 'reset_password_email'
```