### PR TITLE
Fix reset password functionality with path fix in the bash profile.

### DIFF
--- a/helpdesk/bash_profile.sh
+++ b/helpdesk/bash_profile.sh
@@ -10,7 +10,7 @@ if [ "$(id -gn)" == "helpdesk" ]; then
             command sudo -u moc-tools cat "$SCRIPT_DIR/helpdesk/help.txt" | more
         elif [[ $@ =~ ^reset-password ]]; then
             shift 1
-            command sudo -u moc-tools python "$SCRIPT_DIR/helpdesk/reset-password.py" $@
+            command sudo -u moc-tools python "$SCRIPT_DIR/reset-password.py" $@
         elif [[ $@ =~ ^grant-access ]]; then
             shift 1
             command sudo -u moc-tools python "$SCRIPT_DIR/addusers.py" $@


### PR DESCRIPTION
This fix restores the ability to run a password reset as the helpdesk user. The path to reset-password.py in the bash profile is wrong, so if the helpdesk user tries to invoke it, they will get prompted for a sudo password (since sudo is parsed first, this is the error they get, but the command would fail to run anyway, since reset-password.py isn't in the expected path). Presumably, the incorrect path is just a legacy of reset-password.py's old location and the bash profile just wasn't updated to reflect the change.