### PR TITLE
Add the password reset url to the welcome email templates.

### DIFF
--- a/templates/new-user.txt
+++ b/templates/new-user.txt
@@ -1,6 +1,7 @@
 Hi <FULLNAME>,
 
-A user account has been created for you on MOC Production (Kaizen).  Your username is "<USERNAME>".  You will receive a separate email with a link to set your password. The link will expire after 24 hours, so please act promptly.
+A user account has been created for you on MOC Production (Kaizen).  Your username is "<USERNAME>".  You will receive a separate email with a link to set your password. The link will expire after 24 hours, so please act promptly. If your link expires, you may request a new link using the following form:
+<PASSWORD_RESET_FORM_URL>
 
 Once your password is set, you can log in at:
 <LOGIN_URL>

--- a/templates/password.txt
+++ b/templates/password.txt
@@ -5,7 +5,10 @@ Please visit the followiing URL to set your OpenStack password:
 
 You will need the four-digit PIN you provided in the account request form.
 
-This link will expire after 24 hours.  Please contact <SUPPORT_EMAIL> for a new link if you miss the deadline.
+This link will expire after 24 hours. If your link expires, please visit the following page and fill out the form to receive a new link:
+<PASSWORD_RESET_FORM_URL> 
+
+Please contact <SUPPORT_EMAIL> if you have further issues.
 
 Thanks,
 The MOC Team


### PR DESCRIPTION
This PR adds user instructions to the email templates, to reset their passwords should their initial links expire. The link to the password reset form is specified, as well (the actual url lives in settings.ini).