### PR TITLE
Update email templates to reflect the new 48 hr setpass token/url tim…

### DIFF
--- a/templates/new-user.txt
+++ b/templates/new-user.txt
@@ -1,6 +1,6 @@
 Hi <FULLNAME>,
 
-A user account has been created for you on MOC Production (Kaizen).  Your username is "<USERNAME>".  You will receive a separate email with a link to set your password. The link will expire after 24 hours, so please act promptly. If your link expires, you may request a new link using the following form:
+A user account has been created for you on MOC Production (Kaizen).  Your username is "<USERNAME>".  You will receive a separate email with a link to set your password. The link will expire after 48 hours, so please act promptly. If your link expires, you may request a new link using the following form:
 <PASSWORD_RESET_FORM_URL>
 
 Once your password is set, you can log in at:

--- a/templates/password-reset.txt
+++ b/templates/password-reset.txt
@@ -7,7 +7,7 @@ Please visit the followiing URL to set your OpenStack password:
 
 You will need the 4-digit PIN which you provided with the request, or which was communicated to you separately.
 
-This link will expire after 24 hours.  
+This link will expire after 48 hours.  
 
 Thanks,
 The MOC Team

--- a/templates/password.txt
+++ b/templates/password.txt
@@ -5,7 +5,7 @@ Please visit the followiing URL to set your OpenStack password:
 
 You will need the four-digit PIN you provided in the account request form.
 
-This link will expire after 24 hours. If your link expires, please visit the following page and fill out the form to receive a new link:
+This link will expire after 48 hours. If your link expires, please visit the following page and fill out the form to receive a new link:
 <PASSWORD_RESET_FORM_URL> 
 
 Please contact <SUPPORT_EMAIL> if you have further issues.


### PR DESCRIPTION
This PR just updates the email templates to inform users that their password token/urls will expire after 48 hours, rather than 24. This configuration change has already been made to setpass.