### PR TITLE
Resource request expiration

### DIFF
--- a/check-approved-requests.py
+++ b/check-approved-requests.py
@@ -336,19 +336,15 @@ def send_expired_reminders(reminders, worksheet_key):
 
 
 def check_expiration(auth_file, worksheet_key):
-    TIMESTAMP_FORMAT = "%d %b %Y %H:%M:%S"
     warn_time = timedelta(hours=int(config.get('expiration_reminder',
                                                'warn_time')))
     now = datetime.now()
-    timestamp = now.strftime(TIMESTAMP_FORMAT)
-
     sheet = Spreadsheet(keyfile=auth_file, sheet_id=worksheet_key)
     rows = sheet.get_all_rows('Form Responses 1')
     remind_user_list = []
     expired_list = []
 
     parse_function = parse_quota_row
-    csr_type = 'Change Quota'
 
     for idx, row in enumerate(rows):
 
@@ -361,7 +357,7 @@ def check_expiration(auth_file, worksheet_key):
         # if less than warn_time until expiration
         # send a reminder email to the user
         # (should we keep track of if/when we have notified user?)
-        elif ((warn_time + end_date) >= now):
+        if ((warn_time + end_date) >= now):
             remind_user_list.append(row)
 
         # if we are past expiry date
@@ -382,8 +378,6 @@ def check_expiration(auth_file, worksheet_key):
     if expired_list:
         send_expired_reminders(reminders=expired_list,
                                worksheet_key=worksheet_key)
-
-    # do we want to timestamp the spreadsheet?
 
 
 if __name__ == '__main__':

--- a/check-approved-requests.py
+++ b/check-approved-requests.py
@@ -103,7 +103,7 @@ def parse_quota_row(cells):
     # FIXME: this code block is lifted straight from set-quotas.py,
     # farm it out to a function somewhere to streamline updates.  Possibly
     # also update to use a list and for i in range().
-    quotas = {'enddate' : cells[10],
+    quotas = {'enddate': cells[10],
               'instances': cells[11],
               'cores': cells[12],
               'ram': cells[13],
@@ -315,14 +315,15 @@ def send_user_reminder(reminder):
     msg = TemplateMessage(**reminder_cfg)
     msg.send()
 
+
 def send_expired_reminders(reminders, worksheet_key):
-    """Send a reminder email to helpdesk about a quota 
+    """Send a reminder email to helpdesk about a quota
     request which is past the expiration date
     """
     reminder_cfg = dict(config.items('email_defaults'))
     reminder_cfg.update(dict(config.items('expired_reminder')))
     request_details = build_request_details(
-        request_list=reminders, 
+        request_list=reminders,
         template=dict(config.items('reminder'))['detail_template'])
     spreadsheet_link = 'https://docs.google.com/spreadsheets/d/{}'.format(
         worksheet_key)
@@ -333,6 +334,7 @@ def send_expired_reminders(reminders, worksheet_key):
 
     msg = TemplateMessage(**reminder_cfg)
     msg.send()
+
 
 def check_expiration(auth_file, worksheet_key):
     TIMESTAMP_FORMAT = "%d %b %Y %H:%M:%S"
@@ -351,7 +353,7 @@ def check_expiration(auth_file, worksheet_key):
 
     for idx, row in enumerate(rows):
 
-        #skip header row, blank row, or no end date
+        # skip header row, blank row, or no end date
         if (idx == 0) or (row == []) or (row[10] == ''):
             continue
 
@@ -370,20 +372,21 @@ def check_expiration(auth_file, worksheet_key):
             request_info = parse_function(row)
             expired_list.append(request_info)
 
-        #skip rows that are not expired or close to expiring
+        # skip rows that are not expired or close to expiring
         else:
             continue
 
-    #send emails to remind users that their resources are expiring soon
+    # send emails to remind users that their resources are expiring soon
     for reminder in remind_user_list:
         send_user_reminder(reminder=reminder)
 
-    #send email to helpdesk to delete expired resources
+    # send email to helpdesk to delete expired resources
     if expired_list:
         send_expired_reminders(reminders=expired_list,
                                worksheet_key=worksheet_key)
 
-    #do we want to timestamp the spreadsheet?
+    # do we want to timestamp the spreadsheet?
+
 
 if __name__ == '__main__':
 

--- a/check-approved-requests.py
+++ b/check-approved-requests.py
@@ -103,8 +103,7 @@ def parse_quota_row(cells):
     # FIXME: this code block is lifted straight from set-quotas.py,
     # farm it out to a function somewhere to streamline updates.  Possibly
     # also update to use a list and for i in range().
-    quotas = {'enddate': cells[10],
-              'instances': cells[11],
+    quotas = {'instances': cells[11],
               'cores': cells[12],
               'ram': cells[13],
               'floatingip': cells[14],
@@ -363,8 +362,7 @@ def check_expiration(auth_file, worksheet_key):
         # send a reminder email to the user
         # (should we keep track of if/when we have notified user?)
         elif ((warn_time + end_date) >= now):
-            request_info = parse_function(row)
-            remind_user_list.append(request_info)
+            remind_user_list.append(row)
 
         # if we are past expiry date
         # send a notification to helpdesk to terminate resources

--- a/example_settings.ini
+++ b/example_settings.ini
@@ -48,6 +48,25 @@ start =
 # interval at which to send subsequent reminders (in hours)
 interval = 
 
+[expiration_reminder]
+# template for sending a user reminder for quota
+# requests which are expiring soon
+template = templates/user-expiration-reminder.txt
+subject = 
+# time (in hours) before expiration to send reminder to user
+warn_time = 
+
+[expired_reminder]
+# email address & template for sending a reminder for
+# quota requests which are past expiration date
+email = 
+formatting = html
+# Template for the reminder email
+template = templates/helpdesk-expiration-reminder.txt
+detail_template = templates/reminder-detail.txt
+subject = 
+
+
 ## Email settings
 # Specify the values used to customize email messages constructed using the
 # TemplateMessage class. 

--- a/reset-password.py
+++ b/reset-password.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
     setpass = SetpassClient(sess, setpass_url)
     keystone = client.Client(session=sess)
   
-    user = [usr for usr in keystone.users.list() if usr.name == args.username]
+    user = [usr for usr in keystone.users.list() if usr.name.lower() == args.username.lower()]
     if not user:
         print "User {} not found".format(args.username)
         sys.exit(1)

--- a/reset-password.py
+++ b/reset-password.py
@@ -90,8 +90,8 @@ if __name__ == "__main__":
     setpass = SetpassClient(sess, setpass_url)
     keystone = client.Client(session=sess)
   
-    user = [usr for usr in keystone.users.list() 
-    	   if usr.name.lower() == args.username.lower()]
+    user = [usr for usr in keystone.users.list()
+            if usr.name.lower() == args.username.lower()]
     if not user:
         print "User {} not found".format(args.username)
         sys.exit(1)

--- a/reset-password.py
+++ b/reset-password.py
@@ -90,7 +90,7 @@ if __name__ == "__main__":
     setpass = SetpassClient(sess, setpass_url)
     keystone = client.Client(session=sess)
   
-    user = [usr for usr in keystone.users.list() if usr.name.lower() == args.username.lower()]
+    user = [usr for usr in keystone.users.list() if usr.name == args.username]
     if not user:
         print "User {} not found".format(args.username)
         sys.exit(1)

--- a/reset-password.py
+++ b/reset-password.py
@@ -90,7 +90,8 @@ if __name__ == "__main__":
     setpass = SetpassClient(sess, setpass_url)
     keystone = client.Client(session=sess)
   
-    user = [usr for usr in keystone.users.list() if usr.name == args.username]
+    user = [usr for usr in keystone.users.list() 
+    	   if usr.name.lower() == args.username.lower()]
     if not user:
         print "User {} not found".format(args.username)
         sys.exit(1)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [flake8]
-ignore=W293,E402
+ignore=W293,E402,E722

--- a/templates/helpdesk-expiration-reminder.txt
+++ b/templates/helpdesk-expiration-reminder.txt
@@ -1,0 +1,11 @@
+<html>
+<body>
+<p>This is an automated reminder that there are <REQUEST_COUNT> Quota requests that are past expiration date.</p>
+
+<p>Click this link to view the request spreadsheet:<br><a href="<REQUEST_SPREADSHEET>">Quota Request Spreadsheet</a></p>
+
+<p>Details of the requests are below:
+  <pre style="font: monospace"><REQUEST_DETAILS></pre>
+</p>
+</body>
+</html>

--- a/templates/user-expiration-reminder.txt
+++ b/templates/user-expiration-reminder.txt
@@ -1,0 +1,8 @@
+Hi <FULLNAME>,
+
+Your quota request on Mass Open Cloud Production (Kaizen) which you requested on <REQUEST_DATE> for the <PROJECT_NAME> project is expiring on <END_DATE>. Make sure to save any critical data from these resources. Please note that after the expiration date, your resources will be shut down without warning.
+
+If you have any questions, please log a ticket at <SUPPORT_URL> and we will be happy to assist you.
+
+Thanks,
+The MOC Team


### PR DESCRIPTION
In response to #105 

- Check for any requests that are close to or past the expiration date
- If close to expiration date (time defined in settings), send reminder email to user
- If past expiration date, notify helpdesk to terminate the resources

Some questions I have:
- When a quota is expired, is it removed from the spreadsheet? If not, we need to add a column to check this
- I saw some email templates formatted as html and others as raw text, which should it be? I followed example of making user emails raw text and making helpdesk emails html based on existing templates